### PR TITLE
Fixed upgrade of cobertura to version 2.0.3.

### DIFF
--- a/CodeCoverageGrailsPlugin.groovy
+++ b/CodeCoverageGrailsPlugin.groovy
@@ -1,7 +1,7 @@
 class CodeCoverageGrailsPlugin {
-	def version = '1.2.7'
+	def version = '2.0.3-SNAPSHOT'
 
-	def grailsVersion = '1.2 > *'
+	def grailsVersion = '1.3 > *'
 
 	def pluginExcludes = [
 		"grails-app/conf/mavenInfo.groovy"

--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,3 @@
-app.grails.version=2.2.0
+#Grails Metadata file
+#Wed May 28 23:57:52 CEST 2014
+app.grails.version=2.3.9

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,25 +1,38 @@
 grails.project.work.dir = 'target'
+grails.project.class.dir = "target/classes"
+grails.project.test.class.dir = "target/test-classes"
+grails.project.test.reports.dir = "target/test-reports"
+grails.project.work.dir = "target/work"
+grails.project.target.level = 1.5
+grails.project.source.level = 1.5
 
+grails.project.dependency.resolver = "maven"
 grails.project.dependency.resolution = {
+    // inherit Grails' default dependencies
+    inherits("global") {
+    }
+    log "info" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
+    checksums true
+    legacyResolve false
+    repositories {
+        inherits false
+        grailsCentral()
+        mavenLocal()
+        mavenCentral()
+    }
 
-	inherits 'global'
-	log 'warn'
+    dependencies {
+        runtime('org.apache.ant:ant-launcher:1.8.3')
+        runtime 'net.sourceforge.cobertura:cobertura:2.0.3', {
+            excludes 'ant', 'log4j'
+        }
+        runtime 'xerces:xercesImpl:2.11.0'
+        runtime 'xalan:xalan:2.7.1'
+    }
 
-	repositories {
-		grailsCentral()
-		mavenLocal()
-		mavenCentral()
-	}
-
-	dependencies {
-		runtime 'net.sourceforge.cobertura:cobertura:1.9.4.1', {
-			excludes 'ant', 'log4j'
-		}
-	}
-
-	plugins {
-		build ':release:2.2.1', ':rest-client-builder:1.0.3', {
-			export = false
-		}
-	}
+    plugins {
+        build ':release:3.0.1', ':rest-client-builder:1.0.3', {
+            export = false
+        }
+    }
 }


### PR DESCRIPTION
Cobertura 2.0.3 uses ASM 4.1, and since Grails uses 3.3.1
Grails puts version 3.3.1 on the system classpath, and cobertura builds it's classpath for launching the instrumentation, from the system classpath. This means that the Grails ASM (version 3.3.1) is first on the classpath, and that version is incompatible with cobertura.
Maven cannot resolve this (neither can Ivy), since ASM changed groupId between versions, making the two version to different artefacts.

The solution implemented is to launch Ant in a separate JVM with the Grails test classpath, where ASM 3 has been stripped of, and run the cobertura Ant Task InterumentTask from there.
