### PR TITLE
Attempot to fix bug #30

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,4 +1,4 @@
-grails.project.work.dir = 'target'
+    grails.project.work.dir = 'target'
 grails.project.class.dir = "target/classes"
 grails.project.test.class.dir = "target/test-classes"
 grails.project.test.reports.dir = "target/test-reports"
@@ -28,6 +28,7 @@ grails.project.dependency.resolution = {
         }
         runtime 'xerces:xercesImpl:2.11.0'
         runtime 'xalan:xalan:2.7.1'
+        runtime 'org.apache.ant:ant:1.8.4'
     }
 
     plugins {

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,4 +1,4 @@
-    grails.project.work.dir = 'target'
+grails.project.work.dir = 'target'
 grails.project.class.dir = "target/classes"
 grails.project.test.class.dir = "target/test-classes"
 grails.project.test.reports.dir = "target/test-reports"


### PR DESCRIPTION
It seems that the ant 1.8.4 dependency disappears from an upgrade from Grails 2.3.7 to 2.3.8 (and beyond).

This seems to fix the issue on my test project, which I run on both versions
