### PR TITLE
Changed the default Cobertura datafile to default to the project basedir...

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ To force coverage to run (if you have set the enabledByDefault flag to false; se
     grails test-app -coverage
 
 
+The script will place the cobertura.ser file in the project base directory by default. You can override this location with the system property net.sourceforge.cobertura.datafile:
+
+    grails test-app -coverage -Dnet.sourceforge.cobertura.datafile=/some/other/path
+
+
 ## Configuration Options:
 
 If you want to disable coverage by default, you can set the enabledByDefault config attribute equal to false
@@ -123,6 +128,7 @@ or from the command line, the following will create combined results for the uni
 * [Rubén](https://github.com/armeris)
 * [Marcos Carceles](https://github.com/marcos-carceles)
 * [genuinefafa](https://github.com/genuinefafa)
+* [Steve Hendrix](https://github.com/shendrix)
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/beckje01/grails-code-coverage/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -2,7 +2,7 @@ import groovy.xml.MarkupBuilder
 import org.apache.tools.ant.types.Path
 import org.codehaus.groovy.grails.commons.GrailsClassUtils
 
-dataFile = "cobertura.ser"
+dataFile = System.properties["net.sourceforge.cobertura.datafile"] ?: "${basedir}/cobertura.ser"
 
 forkedJVMDebugPort = 0//'5005'
 


### PR DESCRIPTION
..., and allow overriding using net.sourceforge.cobertura.datafile system property
