### PR TITLE
Support for net.sourceforge.cobertura.CoverageIgnore annotation

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -340,10 +340,12 @@ class AntInstrumentationBuildfileBuilder {
                             'exclude'(name: "${pattern}")
                         }
                     }
+                    'ignoreMethodAnnotation'(annotationName: "net.sourceforge.cobertura.CoverageIgnore")
                 }
             }
         }
 
+        println "Using Cobertura with settings:\n ${writer.toString()}"
         return writer.toString()
     }
 }

--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -345,7 +345,7 @@ class AntInstrumentationBuildfileBuilder {
             }
         }
 
-        println "Using Cobertura with settings:\n ${writer.toString()}"
+        //println "Using Cobertura with settings:\n ${writer.toString()}"
         return writer.toString()
     }
 }


### PR DESCRIPTION
Added support for cobertura's net.sourceforge.cobertura.CoverageIgnore annotation, making it possible to ignore trivial methods erroneously flagging branch coverage of Grails/Groovy code.
