### PR TITLE
Malformed class name

### DIFF
--- a/CodeCoverageGrailsPlugin.groovy
+++ b/CodeCoverageGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 class CodeCoverageGrailsPlugin {
-	def version = '2.0.3-4'
+	def version = '2.0.3-4-SNAPSHOT'
 
 	def grailsVersion = '1.3 > *'
 

--- a/CodeCoverageGrailsPlugin.groovy
+++ b/CodeCoverageGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 class CodeCoverageGrailsPlugin {
-	def version = '2.0.3-3'
+	def version = '2.0.3-4'
 
 	def grailsVersion = '1.3 > *'
 

--- a/application.properties
+++ b/application.properties
@@ -1,3 +1,3 @@
 #Grails Metadata file
 #Wed May 28 23:57:52 CEST 2014
-app.grails.version=2.3.9
+app.grails.version=2.4.5


### PR DESCRIPTION
Issue was the difference between Grails versions. As I updated Grails version to 2.4.5, the error was gone.
